### PR TITLE
feat(census): Option A grouped animal schema display on MS

### DIFF
--- a/components/admin/animalCensus/view.tsx
+++ b/components/admin/animalCensus/view.tsx
@@ -306,7 +306,7 @@ const CoverageDetailDrawer = ({
           contained
           columns={[
             {
-              label: t("form.label.species", "Species"),
+              label: t("form.label.species", "Species (heads)"),
               get: record => record.rowLabel,
             },
             {
@@ -314,10 +314,13 @@ const CoverageDetailDrawer = ({
               get: record => record.animalQuantity.toString(),
             },
           ]}
-          data={row.speciesSummary.map(item => ({
-            id: item.rowKey,
-            ...item,
-          }))}
+          data={row.speciesSummary
+            // Backend species_summary already skips group HH rows; filter as safety.
+            .filter(item => !item.rowKey.startsWith("group:"))
+            .map(item => ({
+              id: item.rowKey,
+              ...item,
+            }))}
           viewOnRowClick={false}
         />
       </div>

--- a/components/admin/censusDefinition/builder/index.tsx
+++ b/components/admin/censusDefinition/builder/index.tsx
@@ -906,8 +906,8 @@ function normalizeSchema(
       species_measures: Array.isArray(schema.species_measures)
         ? schema.species_measures
         : Array.isArray(schema.measures) && schema.measures.length
-        ? schema.measures.filter(m => m.key === "animal_quantity")
-        : [measure("animal_quantity", "Animal quantity")],
+          ? schema.measures.filter(m => m.key === "animal_quantity")
+          : [measure("animal_quantity", "Animal quantity")],
       summary_fields: Array.isArray(schema.summary_fields)
         ? schema.summary_fields
         : [

--- a/components/admin/censusDefinition/builder/index.tsx
+++ b/components/admin/censusDefinition/builder/index.tsx
@@ -141,6 +141,14 @@ const CensusDefinitionBuilder = ({
               "censusDefinition.builder.help",
               "Define breakdowns and numeric measures. Rows are generated for mobile when this definition is published."
             )}
+            {kind === "ANIMAL" && isGroupedAnimalSchema(schema) && (
+              <div className="mt-2 rounded border border-blue-200 bg-blue-50 px-3 py-2 text-blue-800">
+                {t(
+                  "censusDefinition.builder.groupedHelp",
+                  "Grouped animal form (Option A): each group has one household count; each species has headcount only (including Pig HH on group:PIG). Prefer JSON mode to edit groups."
+                )}
+              </div>
+            )}
           </div>
         </div>
         <div className="inline-flex overflow-hidden rounded border border-gray-300">
@@ -875,11 +883,41 @@ type ValidationError = {
   fallback: string;
 };
 
+function isGroupedAnimalSchema(schema: CensusDefinitionAuthoredSchema) {
+  return (
+    schema.schema_version === 2 ||
+    (Array.isArray(schema.groups) && schema.groups.length > 0)
+  );
+}
+
 function normalizeSchema(
   schema: CensusDefinitionAuthoredSchema,
   kind: CensusKind
 ): CensusDefinitionAuthoredSchema {
-  const normalized = {
+  // Option A: preserve group HH + species heads schema end-to-end
+  if (kind === "ANIMAL" && isGroupedAnimalSchema(schema)) {
+    return {
+      ...schema,
+      schema_version: schema.schema_version ?? 2,
+      groups: Array.isArray(schema.groups) ? schema.groups : [],
+      group_measures: Array.isArray(schema.group_measures)
+        ? schema.group_measures
+        : [measure("household_quantity", "Households")],
+      species_measures: Array.isArray(schema.species_measures)
+        ? schema.species_measures
+        : Array.isArray(schema.measures) && schema.measures.length
+        ? schema.measures.filter(m => m.key === "animal_quantity")
+        : [measure("animal_quantity", "Animal quantity")],
+      summary_fields: Array.isArray(schema.summary_fields)
+        ? schema.summary_fields
+        : [
+            measure("village_household_quantity", "HH No."),
+            measure("animal_household_quantity", "Animal HH No."),
+          ],
+    };
+  }
+
+  const normalized: CensusDefinitionAuthoredSchema = {
     schema_version: schema.schema_version ?? 1,
     display: schema.display ?? {
       single_row_label: { default: "Total" },
@@ -887,7 +925,7 @@ function normalizeSchema(
     dimensions: Array.isArray(schema.dimensions) ? schema.dimensions : [],
     measures: Array.isArray(schema.measures) ? schema.measures : [],
   };
-  if (normalized.measures.length === 0) {
+  if (!normalized.measures || normalized.measures.length === 0) {
     normalized.measures =
       kind === "ANIMAL"
         ? [
@@ -1056,6 +1094,61 @@ function validateSchema(
   schema: CensusDefinitionAuthoredSchema
 ): ValidationError[] {
   const errors: ValidationError[] = [];
+
+  // Option A grouped animal schema (edit primarily via JSON mode for now)
+  if (isGroupedAnimalSchema(schema)) {
+    const groups = schema.groups ?? [];
+    if (groups.length === 0) {
+      errors.push({
+        path: "groups",
+        key: "groupsRequired",
+        fallback: "At least one group is required.",
+      });
+    }
+    validateUniqueKeys(groups, "groups", errors);
+    const seenSpecies = new Set<string>();
+    groups.forEach((group, index) => {
+      if (!labelText(group.label, "").trim()) {
+        errors.push({
+          path: `groups.${index}.label`,
+          key: "labelRequired",
+          fallback: "Label is required.",
+        });
+      }
+      if (!group.species?.length) {
+        errors.push({
+          path: `groups.${index}.species`,
+          key: "valuesRequired",
+          fallback: "At least one species is required.",
+        });
+      }
+      (group.species ?? []).forEach((species, speciesIndex) => {
+        if (!species.key) {
+          errors.push({
+            path: `groups.${index}.species.${speciesIndex}.key`,
+            key: "keyRequired",
+            fallback: "Key is required.",
+          });
+        } else if (seenSpecies.has(species.key)) {
+          errors.push({
+            path: `groups.${index}.species.${speciesIndex}.key`,
+            key: "keyUnique",
+            fallback: "Species key must be unique.",
+          });
+        }
+        seenSpecies.add(species.key);
+        if (!labelText(species.label, "").trim()) {
+          errors.push({
+            path: `groups.${index}.species.${speciesIndex}.label`,
+            key: "labelRequired",
+            fallback: "Label is required.",
+          });
+        }
+      });
+    });
+    return errors;
+  }
+
   const dimensions = schema.dimensions ?? [];
   const measures = schema.measures ?? [];
   validateUniqueKeys(dimensions, "dimensions", errors);

--- a/components/admin/censusDefinition/detail.tsx
+++ b/components/admin/censusDefinition/detail.tsx
@@ -69,6 +69,18 @@ const CensusDefinitionDetail = ({ kind }: Props) => {
                 value={activeVersion?.status ?? "-"}
               />
               <DetailRow
+                label={t("form.label.layout", "Layout")}
+                value={
+                  (activeVersion?.runtimeSchema as { layout?: string })
+                    ?.layout === "grouped_species"
+                    ? t(
+                        "censusDefinition.layout.grouped",
+                        "Grouped (group HH + species heads)"
+                      )
+                    : t("censusDefinition.layout.flat", "Flat")
+                }
+              />
+              <DetailRow
                 label={t("form.label.rows", "Rows")}
                 value={(
                   activeVersion?.runtimeSchema.rows?.length ?? 0
@@ -80,6 +92,28 @@ const CensusDefinitionDetail = ({ kind }: Props) => {
                   activeVersion?.runtimeSchema.measures?.length ?? 0
                 ).toString()}
               />
+              {Array.isArray(
+                (authoredSchema as { groups?: unknown[] }).groups
+              ) &&
+                (authoredSchema as { groups: Array<{ key: string; label: any; species?: Array<{ key: string; label: any }> }> }).groups.map(
+                  group => (
+                    <DetailRow
+                      key={group.key}
+                      label={`${t("censusDefinition.group", "Group")}: ${
+                        typeof group.label === "object"
+                          ? group.label?.default ?? group.key
+                          : group.label ?? group.key
+                      }`}
+                      value={(group.species ?? [])
+                        .map(s =>
+                          typeof s.label === "object"
+                            ? s.label?.default ?? s.key
+                            : s.label ?? s.key
+                        )
+                        .join(", ")}
+                    />
+                  )
+                )}
               <DetailRow
                 label={t("form.label.publishedAt", "Published At")}
                 value={formatPublishedAt(activeVersion?.publishedAt) || "-"}

--- a/components/admin/censusDefinition/detail.tsx
+++ b/components/admin/censusDefinition/detail.tsx
@@ -95,25 +95,31 @@ const CensusDefinitionDetail = ({ kind }: Props) => {
               {Array.isArray(
                 (authoredSchema as { groups?: unknown[] }).groups
               ) &&
-                (authoredSchema as { groups: Array<{ key: string; label: any; species?: Array<{ key: string; label: any }> }> }).groups.map(
-                  group => (
-                    <DetailRow
-                      key={group.key}
-                      label={`${t("censusDefinition.group", "Group")}: ${
-                        typeof group.label === "object"
-                          ? group.label?.default ?? group.key
-                          : group.label ?? group.key
-                      }`}
-                      value={(group.species ?? [])
-                        .map(s =>
-                          typeof s.label === "object"
-                            ? s.label?.default ?? s.key
-                            : s.label ?? s.key
-                        )
-                        .join(", ")}
-                    />
-                  )
-                )}
+                (
+                  authoredSchema as {
+                    groups: Array<{
+                      key: string;
+                      label: any;
+                      species?: Array<{ key: string; label: any }>;
+                    }>;
+                  }
+                ).groups.map(group => (
+                  <DetailRow
+                    key={group.key}
+                    label={`${t("censusDefinition.group", "Group")}: ${
+                      typeof group.label === "object"
+                        ? (group.label?.default ?? group.key)
+                        : (group.label ?? group.key)
+                    }`}
+                    value={(group.species ?? [])
+                      .map(s =>
+                        typeof s.label === "object"
+                          ? (s.label?.default ?? s.key)
+                          : (s.label ?? s.key)
+                      )
+                      .join(", ")}
+                  />
+                ))}
               <DetailRow
                 label={t("form.label.publishedAt", "Published At")}
                 value={formatPublishedAt(activeVersion?.publishedAt) || "-"}

--- a/components/admin/village/view.tsx
+++ b/components/admin/village/view.tsx
@@ -7,6 +7,12 @@ import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  formatCensusFactAnimals,
+  formatCensusFactHouseholds,
+  isGroupCensusRowKey,
+  isSpeciesCensusRowKey,
+} from "lib/services/census/rowKind";
 import { roundCoordinate } from "./coordinates";
 import { VillageViewViewModel } from "./viewViewModel";
 
@@ -154,16 +160,33 @@ const VillageView = () => {
             <Table
               columns={[
                 {
-                  label: t("form.label.species", "Species"),
+                  label: t("form.label.row", "Row"),
                   get: record => record.rowLabel,
                 },
                 {
+                  label: t("form.label.kind", "Kind"),
+                  get: record =>
+                    isGroupCensusRowKey(record.rowKey)
+                      ? t("census.rowKind.group", "Group HH")
+                      : isSpeciesCensusRowKey(record.rowKey)
+                      ? t("census.rowKind.species", "Species")
+                      : t("census.rowKind.legacy", "Species"),
+                },
+                {
                   label: t("form.label.animals", "Animals"),
-                  get: record => record.animalQuantity.toString(),
+                  get: record =>
+                    formatCensusFactAnimals(
+                      record.rowKey,
+                      record.animalQuantity
+                    ),
                 },
                 {
                   label: t("form.label.households", "Households"),
-                  get: record => record.householdQuantity.toString(),
+                  get: record =>
+                    formatCensusFactHouseholds(
+                      record.rowKey,
+                      record.householdQuantity
+                    ),
                 },
               ]}
               data={viewModel.latestCensus.facts.map(fact => ({

--- a/components/admin/village/view.tsx
+++ b/components/admin/village/view.tsx
@@ -169,8 +169,8 @@ const VillageView = () => {
                     isGroupCensusRowKey(record.rowKey)
                       ? t("census.rowKind.group", "Group HH")
                       : isSpeciesCensusRowKey(record.rowKey)
-                      ? t("census.rowKind.species", "Species")
-                      : t("census.rowKind.legacy", "Species"),
+                        ? t("census.rowKind.species", "Species")
+                        : t("census.rowKind.legacy", "Species"),
                 },
                 {
                   label: t("form.label.animals", "Animals"),

--- a/lib/services/census/definition.ts
+++ b/lib/services/census/definition.ts
@@ -44,13 +44,31 @@ export type CensusDefinitionSchemaDimension = {
   values: CensusDefinitionSchemaValue[];
 };
 
+/** Option A: shared group HH row + per-species headcount rows. */
+export type CensusDefinitionSchemaSpecies = {
+  key: string;
+  label: LocalizedLabel;
+};
+
+export type CensusDefinitionSchemaGroup = {
+  key: string;
+  label: LocalizedLabel;
+  species: CensusDefinitionSchemaSpecies[];
+};
+
 export type CensusDefinitionAuthoredSchema = {
   schema_version?: number;
   display?: {
     single_row_label?: LocalizedLabel;
   };
+  /** v1 flat Cartesian breakdowns */
   dimensions?: CensusDefinitionSchemaDimension[];
   measures?: CensusSchemaMeasure[];
+  /** v2 Option A: group HH + species heads */
+  summary_fields?: CensusSchemaMeasure[];
+  group_measures?: CensusSchemaMeasure[];
+  species_measures?: CensusSchemaMeasure[];
+  groups?: CensusDefinitionSchemaGroup[];
   [key: string]: unknown;
 };
 

--- a/lib/services/census/definition.ts
+++ b/lib/services/census/definition.ts
@@ -18,6 +18,14 @@ export type CensusSchemaRow = {
 };
 
 export type CensusSchema = {
+  schema_version?: number;
+  layout?: "flat" | "grouped_species" | string;
+  groups?: Array<{
+    key?: string;
+    label?: LocalizedLabel | string;
+    household_row_key?: string;
+    species_row_keys?: string[];
+  }>;
   rows?: CensusSchemaRow[];
   measures?: CensusSchemaMeasure[];
   row_source?: "ACTIVE_ANIMAL_SPECIES" | string;

--- a/lib/services/census/index.ts
+++ b/lib/services/census/index.ts
@@ -34,3 +34,11 @@ export type {
   CensusCapabilities,
   ICensusCapabilityService,
 } from "./capabilityService";
+
+export {
+  censusRowKindLabel,
+  formatCensusFactAnimals,
+  formatCensusFactHouseholds,
+  isGroupCensusRowKey,
+  isSpeciesCensusRowKey,
+} from "./rowKind";

--- a/lib/services/census/rowKind.ts
+++ b/lib/services/census/rowKind.ts
@@ -1,0 +1,51 @@
+/**
+ * Option A animal census fact rows:
+ * - group:*  → household_quantity only
+ * - species:* → animal_quantity only
+ */
+
+export function isGroupCensusRowKey(rowKey?: string | null): boolean {
+  return !!rowKey && rowKey.startsWith("group:");
+}
+
+export function isSpeciesCensusRowKey(rowKey?: string | null): boolean {
+  return !!rowKey && rowKey.startsWith("species:");
+}
+
+export function censusRowKindLabel(
+  rowKey: string,
+  groupLabel = "Group HH",
+  speciesLabel = "Species"
+): string {
+  if (isGroupCensusRowKey(rowKey)) {
+    return groupLabel;
+  }
+  if (isSpeciesCensusRowKey(rowKey)) {
+    return speciesLabel;
+  }
+  return speciesLabel;
+}
+
+export function formatCensusFactHouseholds(
+  rowKey: string,
+  householdQuantity: number
+): string {
+  if (isGroupCensusRowKey(rowKey)) {
+    return String(householdQuantity ?? 0);
+  }
+  if (isSpeciesCensusRowKey(rowKey)) {
+    return "—";
+  }
+  // Legacy flat rows: both measures on each species row
+  return String(householdQuantity ?? 0);
+}
+
+export function formatCensusFactAnimals(
+  rowKey: string,
+  animalQuantity: number
+): string {
+  if (isGroupCensusRowKey(rowKey)) {
+    return "—";
+  }
+  return String(animalQuantity ?? 0);
+}


### PR DESCRIPTION
## Summary
- Preserve Option A `groups` / summary / measures in census definition builder.
- Definition detail shows grouped layout and group→species list.
- Village snapshot and coverage detail distinguish group HH vs species heads.

## Test plan
- [x] Prettier / lint on commit
- [ ] Verify admin census definition detail after API publishes v2 schema