### PR TITLE
feat(report): metric accumulation admin and incident totals

### DIFF
--- a/components/admin/reportType/create.tsx
+++ b/components/admin/reportType/create.tsx
@@ -264,6 +264,31 @@ const ReportTypeCreate = () => {
           </>
           {rendererDataTemplateField}
           <>{viewModel.isFollowable && rendererFollowupDataTemplateField}</>
+          <>
+            {viewModel.isFollowable && (
+              <Field $size="half">
+                <Label htmlFor="metricAccumulation">
+                  {t(
+                    "form.label.metricAccumulation",
+                    "Metric accumulation (JSON)"
+                  )}
+                </Label>
+                <TextArea
+                  id="metricAccumulation"
+                  placeholder='{"version":1,"metrics":[{"id":"num_sick","reportField":"num_sick","followupField":"num_sick","op":"sum"}]}'
+                  rows={12}
+                  onChange={evt =>
+                    (viewModel.metricAccumulation = evt.target.value)
+                  }
+                  disabled={viewModel.isSubmitting}
+                  value={viewModel.metricAccumulation}
+                />
+                <ErrorText>
+                  {viewModel.fieldErrors.metricAccumulation}
+                </ErrorText>
+              </Field>
+            )}
+          </>
           <Field $size="half">
             <Label htmlFor="stateDefinitionId">State definition</Label>
             <Select

--- a/components/admin/reportType/createViewModel.ts
+++ b/components/admin/reportType/createViewModel.ts
@@ -13,7 +13,8 @@ export class ReportTypeCreateViewModel extends ReportTypeViewModel {
       this.rendererDataTemplate,
       this.followupDefinition,
       this.rendererFollowupDataTemplate,
-      this.isFollowable
+      this.isFollowable,
+      this.metricAccumulation
     );
   }
 }

--- a/components/admin/reportType/listViewModel.ts
+++ b/components/admin/reportType/listViewModel.ts
@@ -160,7 +160,9 @@ export class AdminReportTypeListViewModel extends BaseViewModel {
       data.stateDefinitionId,
       data.rendererDataTemplate,
       JSON.stringify(data.followupDefinition, null, 2),
-      data.rendererFollowupDataTemplate
+      data.rendererFollowupDataTemplate,
+      data.isFollowable,
+      data.metricAccumulation
     );
   }
 
@@ -174,7 +176,9 @@ export class AdminReportTypeListViewModel extends BaseViewModel {
       data.stateDefinitionId,
       data.rendererDataTemplate,
       JSON.stringify(data.followupDefinition, null, 2),
-      data.rendererFollowupDataTemplate
+      data.rendererFollowupDataTemplate,
+      data.isFollowable,
+      data.metricAccumulation
     );
   }
 

--- a/components/admin/reportType/listViewModel.ts
+++ b/components/admin/reportType/listViewModel.ts
@@ -92,6 +92,10 @@ export class AdminReportTypeListViewModel extends BaseViewModel {
                 followupDefinition: JSON.parse(data.followupDefinition || "{}"),
                 rendererFollowupDataTemplate:
                   data.rendererFollowupDataTemplate || "",
+                isFollowable: data.isFollowable || false,
+                metricAccumulation: data.metricAccumulation
+                  ? JSON.parse(data.metricAccumulation || "{}")
+                  : null,
               },
               null,
               2
@@ -151,6 +155,18 @@ export class AdminReportTypeListViewModel extends BaseViewModel {
     return result.success;
   }
 
+  _normalizeMetricAccumulation(
+    value: ReportType["metricAccumulation"] | Record<string, unknown> | null
+  ): string | undefined {
+    if (value == null || value === "") {
+      return undefined;
+    }
+    if (typeof value === "string") {
+      return value;
+    }
+    return JSON.stringify(value, null, 2);
+  }
+
   _createReportType(data: ReportType): Promise<SaveResult<ReportType>> {
     return this.reportTypeService.createReportType(
       data.name,
@@ -162,7 +178,7 @@ export class AdminReportTypeListViewModel extends BaseViewModel {
       JSON.stringify(data.followupDefinition, null, 2),
       data.rendererFollowupDataTemplate,
       data.isFollowable,
-      data.metricAccumulation
+      this._normalizeMetricAccumulation(data.metricAccumulation)
     );
   }
 
@@ -178,7 +194,7 @@ export class AdminReportTypeListViewModel extends BaseViewModel {
       JSON.stringify(data.followupDefinition, null, 2),
       data.rendererFollowupDataTemplate,
       data.isFollowable,
-      data.metricAccumulation
+      this._normalizeMetricAccumulation(data.metricAccumulation)
     );
   }
 

--- a/components/admin/reportType/reportTypeViewModel.ts
+++ b/components/admin/reportType/reportTypeViewModel.ts
@@ -17,6 +17,7 @@ export abstract class ReportTypeViewModel extends BaseFormViewModel {
   _followupDefinition: string = "";
   _rendererFollowupDataTemplate: string = "";
   _isFollowable: boolean = false;
+  _metricAccumulation: string = "";
 
   definitionFormViewModel: FormViewModel;
   followupDefinitionFormViewModel: FormViewModel;
@@ -98,6 +99,8 @@ export abstract class ReportTypeViewModel extends BaseFormViewModel {
       rendererFollowupDataTemplate: computed,
       _isFollowable: observable,
       isFollowable: computed,
+      _metricAccumulation: observable,
+      metricAccumulation: computed,
       save: action,
       validate: action,
       definitionFormViewModel: observable,
@@ -154,6 +157,14 @@ export abstract class ReportTypeViewModel extends BaseFormViewModel {
   }
   public set isFollowable(value: boolean) {
     this._isFollowable = value;
+  }
+
+  public get metricAccumulation(): string {
+    return this._metricAccumulation;
+  }
+  public set metricAccumulation(value: string) {
+    this._metricAccumulation = value;
+    this.clearError("metricAccumulation");
   }
 
   public parseFollowupDefinition(value: string): boolean {

--- a/components/admin/reportType/reportTypeViewModel.ts
+++ b/components/admin/reportType/reportTypeViewModel.ts
@@ -270,6 +270,25 @@ export abstract class ReportTypeViewModel extends BaseFormViewModel {
       this.fieldErrors["categoryId"] = "this field is required";
     }
 
+    if (this.metricAccumulation && this.metricAccumulation.trim().length > 0) {
+      try {
+        const parsed = JSON.parse(this.metricAccumulation);
+        if (
+          parsed != null &&
+          typeof parsed === "object" &&
+          parsed.metrics != null &&
+          !Array.isArray(parsed.metrics)
+        ) {
+          isValid = false;
+          this.fieldErrors["metricAccumulation"] =
+            "metrics must be an array when present";
+        }
+      } catch {
+        isValid = false;
+        this.fieldErrors["metricAccumulation"] = "must be valid JSON";
+      }
+    }
+
     return isValid;
   }
 }

--- a/components/admin/reportType/update.tsx
+++ b/components/admin/reportType/update.tsx
@@ -174,6 +174,37 @@ const ReportTypeUpdateForm = () => {
     [t, viewModel]
   );
 
+  const metricAccumulationField = useMemo(
+    () => (
+      <Observer>
+        {() =>
+          viewModel.isFollowable ? (
+            <Field $size="half">
+              <Label htmlFor="metricAccumulation">
+                {t(
+                  "form.label.metricAccumulation",
+                  "Metric accumulation (JSON)"
+                )}
+              </Label>
+              <TextArea
+                id="metricAccumulation"
+                placeholder='{"version":1,"metrics":[{"id":"num_sick","reportField":"num_sick","followupField":"num_sick","op":"sum"}]}'
+                rows={12}
+                onChange={evt =>
+                  (viewModel.metricAccumulation = evt.target.value)
+                }
+                disabled={viewModel.isSubmitting}
+                value={viewModel.metricAccumulation}
+              />
+              <ErrorText>{viewModel.fieldErrors.metricAccumulation}</ErrorText>
+            </Field>
+          ) : null
+        }
+      </Observer>
+    ),
+    [t, viewModel]
+  );
+
   const followupDefinitionField = useMemo(
     () => (
       <Observer>
@@ -355,6 +386,7 @@ const ReportTypeUpdateForm = () => {
             <>{viewModel.isFollowable && followupDefinitionField}</>
             {rendererDataTemplateField}
             <>{viewModel.isFollowable && rendererFollowupDataTemplateField}</>
+            {metricAccumulationField}
             {stateDefinitionIdField}
             {orderingField}
           </FieldGroup>

--- a/components/admin/reportType/updateViewModel.ts
+++ b/components/admin/reportType/updateViewModel.ts
@@ -29,6 +29,7 @@ export class ReportTypeUpdateViewModel extends ReportTypeViewModel {
       this.rendererFollowupDataTemplate =
         data.rendererFollowupDataTemplate || "";
       this.isFollowable = data.isFollowable || false;
+      this.metricAccumulation = data.metricAccumulation || "";
     }
     this.isLoading = false;
   }
@@ -45,7 +46,8 @@ export class ReportTypeUpdateViewModel extends ReportTypeViewModel {
       this.rendererDataTemplate,
       this.followupDefinition,
       this.rendererFollowupDataTemplate,
-      this.isFollowable
+      this.isFollowable,
+      this.metricAccumulation
     );
   }
 }

--- a/components/report/report.tsx
+++ b/components/report/report.tsx
@@ -218,6 +218,32 @@ const Report = (props: { id: string }) => {
                 <p className="text-sm pt-1 font-bold">
                   {viewModel.data.rendererData}
                 </p>
+                {viewModel.data.accumulatedMetrics?.metrics &&
+                  viewModel.data.accumulatedMetrics.metrics.length > 0 && (
+                    <div className="mt-3 p-3 rounded border border-gray-200 bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+                      <p className="text-sm font-semibold mb-2">
+                        {t(
+                          "form.label.accumulatedTotals",
+                          "Totals (report + follow-ups)"
+                        )}
+                      </p>
+                      <ul className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-sm">
+                        {viewModel.data.accumulatedMetrics.metrics.map(
+                          metric => (
+                            <li
+                              key={metric.id}
+                              className="flex justify-between gap-2 border-b border-gray-100 dark:border-gray-700 pb-1"
+                            >
+                              <span className="text-gray-600 dark:text-gray-300">
+                                {metric.label || metric.id}
+                              </span>
+                              <span className="font-bold">{metric.value}</span>
+                            </li>
+                          )
+                        )}
+                      </ul>
+                    </div>
+                  )}
               </div>
               <Divide hilight={true} />
 

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -10409,6 +10409,18 @@
             "deprecationReason": null
           },
           {
+            "name": "metricAccumulation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONString",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "name",
             "description": null,
             "args": [],
@@ -10700,6 +10712,18 @@
                 "name": "Boolean",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metricAccumulation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "GenericScalar",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -19225,6 +19249,18 @@
         "isOneOf": null,
         "fields": [
           {
+            "name": "accumulatedMetrics",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "GenericScalar",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "authorities",
             "description": null,
             "args": [],
@@ -24562,6 +24598,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "metricAccumulation",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": "null",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "name",
                 "description": null,
                 "type": {
@@ -24740,6 +24788,18 @@
                   "ofType": null
                 },
                 "defaultValue": "false",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "metricAccumulation",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": "null",
                 "isDeprecated": false,
                 "deprecationReason": null
               },
@@ -36925,6 +36985,18 @@
                 "name": "Boolean",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metricAccumulation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "GenericScalar",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/lib/generated/graphql.tsx
+++ b/lib/generated/graphql.tsx
@@ -1307,6 +1307,7 @@ export type AdminReportTypeCreateSuccess = {
   id: Scalars["UUID"]["output"];
   incidentreports: Array<IncidentReportType>;
   isFollowable: Scalars["Boolean"]["output"];
+  metricAccumulation?: Maybe<Scalars["JSONString"]["output"]>;
   name: Scalars["String"]["output"];
   notificationtemplateSet: Array<AdminNotificationTemplateCreateSuccess>;
   ordering: Scalars["Int"]["output"];
@@ -1331,6 +1332,7 @@ export type AdminReportTypeQueryType = {
   definition: Scalars["JSONString"]["output"];
   id: Scalars["UUID"]["output"];
   isFollowable: Scalars["Boolean"]["output"];
+  metricAccumulation?: Maybe<Scalars["GenericScalar"]["output"]>;
   name: Scalars["String"]["output"];
   ordering: Scalars["Int"]["output"];
   published: Scalars["Boolean"]["output"];
@@ -2351,6 +2353,7 @@ export type ImageType = {
 
 export type IncidentReportType = {
   __typename?: "IncidentReportType";
+  accumulatedMetrics?: Maybe<Scalars["GenericScalar"]["output"]>;
   authorities?: Maybe<Array<Maybe<AuthorityType>>>;
   caseId?: Maybe<Scalars["UUID"]["output"]>;
   coverImage?: Maybe<ImageType>;
@@ -3015,6 +3018,7 @@ export type MutationAdminReportTypeCreateArgs = {
   definition: Scalars["String"]["input"];
   followupDefinition?: InputMaybe<Scalars["String"]["input"]>;
   isFollowable?: InputMaybe<Scalars["Boolean"]["input"]>;
+  metricAccumulation?: InputMaybe<Scalars["String"]["input"]>;
   name: Scalars["String"]["input"];
   ordering: Scalars["Int"]["input"];
   rendererDataTemplate?: InputMaybe<Scalars["String"]["input"]>;
@@ -3032,6 +3036,7 @@ export type MutationAdminReportTypeUpdateArgs = {
   followupDefinition?: InputMaybe<Scalars["String"]["input"]>;
   id: Scalars["ID"]["input"];
   isFollowable?: InputMaybe<Scalars["Boolean"]["input"]>;
+  metricAccumulation?: InputMaybe<Scalars["String"]["input"]>;
   name: Scalars["String"]["input"];
   ordering: Scalars["Int"]["input"];
   rendererDataTemplate?: InputMaybe<Scalars["String"]["input"]>;
@@ -4384,6 +4389,7 @@ export type ReportTypeType = {
   id: Scalars["UUID"]["output"];
   incidentreports: Array<IncidentReportType>;
   isFollowable: Scalars["Boolean"]["output"];
+  metricAccumulation?: Maybe<Scalars["GenericScalar"]["output"]>;
   name: Scalars["String"]["output"];
   notificationtemplateSet: Array<AdminNotificationTemplateCreateSuccess>;
   ordering: Scalars["Int"]["output"];
@@ -8273,6 +8279,7 @@ export type GetReportQuery = {
     caseId?: any | null;
     threadId?: number | null;
     data?: any | null;
+    accumulatedMetrics?: any | null;
     platform?: string | null;
     testFlag: boolean;
     definition?: any | null;
@@ -8281,6 +8288,7 @@ export type GetReportQuery = {
       id: any;
       name: string;
       definition?: any | null;
+      metricAccumulation?: any | null;
     } | null;
     coverImage?: {
       __typename?: "ImageType";
@@ -8667,6 +8675,7 @@ export type ReportTypeCreateMutationVariables = Exact<{
   followupDefinition?: InputMaybe<Scalars["String"]["input"]>;
   rendererFollowupDataTemplate?: InputMaybe<Scalars["String"]["input"]>;
   isFollowable?: InputMaybe<Scalars["Boolean"]["input"]>;
+  metricAccumulation?: InputMaybe<Scalars["String"]["input"]>;
 }>;
 
 export type ReportTypeCreateMutation = {
@@ -8699,6 +8708,7 @@ export type ReportTypeUpdateMutationVariables = Exact<{
   followupDefinition?: InputMaybe<Scalars["String"]["input"]>;
   rendererFollowupDataTemplate?: InputMaybe<Scalars["String"]["input"]>;
   isFollowable?: InputMaybe<Scalars["Boolean"]["input"]>;
+  metricAccumulation?: InputMaybe<Scalars["String"]["input"]>;
 }>;
 
 export type ReportTypeUpdateMutation = {
@@ -8726,6 +8736,7 @@ export type ReportTypeUpdateMutation = {
             followupDefinition?: any | null;
             rendererFollowupDataTemplate?: string | null;
             isFollowable: boolean;
+            metricAccumulation?: any | null;
             ordering: number;
             category?: {
               __typename?: "CategoryType";
@@ -8794,6 +8805,7 @@ export type GetReportTypeQuery = {
     followupDefinition?: any | null;
     rendererFollowupDataTemplate?: string | null;
     isFollowable: boolean;
+    metricAccumulation?: any | null;
     ordering: number;
     category?: { __typename?: "CategoryType"; id: string; name: string } | null;
     stateDefinition?: {
@@ -25491,6 +25503,10 @@ export const GetReportDocument = {
                 { kind: "Field", name: { kind: "Name", value: "data" } },
                 {
                   kind: "Field",
+                  name: { kind: "Name", value: "accumulatedMetrics" },
+                },
+                {
+                  kind: "Field",
                   name: { kind: "Name", value: "reportType" },
                   selectionSet: {
                     kind: "SelectionSet",
@@ -25500,6 +25516,10 @@ export const GetReportDocument = {
                       {
                         kind: "Field",
                         name: { kind: "Name", value: "definition" },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "metricAccumulation" },
                       },
                     ],
                   },
@@ -27035,6 +27055,14 @@ export const ReportTypeCreateDocument = {
           },
           type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
         },
+        {
+          kind: "VariableDefinition",
+          variable: {
+            kind: "Variable",
+            name: { kind: "Name", value: "metricAccumulation" },
+          },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
       ],
       selectionSet: {
         kind: "SelectionSet",
@@ -27113,6 +27141,14 @@ export const ReportTypeCreateDocument = {
                 value: {
                   kind: "Variable",
                   name: { kind: "Name", value: "isFollowable" },
+                },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "metricAccumulation" },
+                value: {
+                  kind: "Variable",
+                  name: { kind: "Name", value: "metricAccumulation" },
                 },
               },
             ],
@@ -27305,6 +27341,14 @@ export const ReportTypeUpdateDocument = {
           },
           type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
         },
+        {
+          kind: "VariableDefinition",
+          variable: {
+            kind: "Variable",
+            name: { kind: "Name", value: "metricAccumulation" },
+          },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
       ],
       selectionSet: {
         kind: "SelectionSet",
@@ -27391,6 +27435,14 @@ export const ReportTypeUpdateDocument = {
                 value: {
                   kind: "Variable",
                   name: { kind: "Name", value: "isFollowable" },
+                },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "metricAccumulation" },
+                value: {
+                  kind: "Variable",
+                  name: { kind: "Name", value: "metricAccumulation" },
                 },
               },
             ],
@@ -27500,6 +27552,13 @@ export const ReportTypeUpdateDocument = {
                                     name: {
                                       kind: "Name",
                                       value: "isFollowable",
+                                    },
+                                  },
+                                  {
+                                    kind: "Field",
+                                    name: {
+                                      kind: "Name",
+                                      value: "metricAccumulation",
                                     },
                                   },
                                   {
@@ -27806,6 +27865,10 @@ export const GetReportTypeDocument = {
                 {
                   kind: "Field",
                   name: { kind: "Name", value: "isFollowable" },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "metricAccumulation" },
                 },
                 { kind: "Field", name: { kind: "Name", value: "ordering" } },
               ],

--- a/lib/services/report/report.graphql
+++ b/lib/services/report/report.graphql
@@ -139,10 +139,12 @@ query GetReport($id: ID!) {
     gpsLocation
     threadId
     data
+    accumulatedMetrics
     reportType {
       id
       name
       definition
+      metricAccumulation
     }
     platform
     coverImage {

--- a/lib/services/report/report.ts
+++ b/lib/services/report/report.ts
@@ -60,10 +60,25 @@ export type UploadFile = {
   fileUrl: string;
 };
 
+export type AccumulatedMetric = {
+  id: string;
+  label?: string;
+  op?: string;
+  reportValue?: number;
+  followupValues?: number[];
+  value: number;
+};
+
+export type AccumulatedMetrics = {
+  version?: number;
+  metrics?: AccumulatedMetric[];
+};
+
 export type ReportDetail = Report & {
   data: Record<string, string> | Record<string, Record<string, string>>;
   images: Array<Image>;
   files: Array<UploadFile>;
   reportTypeDefinition?: Record<string, any>;
   riskAssessmentHistory?: RiskAssessment[];
+  accumulatedMetrics?: AccumulatedMetrics | null;
 };

--- a/lib/services/report/reportService.ts
+++ b/lib/services/report/reportService.ts
@@ -229,6 +229,7 @@ export class ReportService implements IReportService {
           incidentReport.riskAssessmentHistory
             ?.map(mapRiskAssessment)
             .filter(isRiskAssessment) || [],
+        accumulatedMetrics: incidentReport.accumulatedMetrics || null,
       };
     }
     return {

--- a/lib/services/reportType/reportType.graphql
+++ b/lib/services/reportType/reportType.graphql
@@ -75,6 +75,7 @@ mutation ReportTypeCreate(
   $followupDefinition: String
   $rendererFollowupDataTemplate: String
   $isFollowable: Boolean
+  $metricAccumulation: String
 ) {
   adminReportTypeCreate(
     categoryId: $categoryId
@@ -86,6 +87,7 @@ mutation ReportTypeCreate(
     followupDefinition: $followupDefinition
     rendererFollowupDataTemplate: $rendererFollowupDataTemplate
     isFollowable: $isFollowable
+    metricAccumulation: $metricAccumulation
   ) {
     result {
       __typename
@@ -115,6 +117,7 @@ mutation ReportTypeUpdate(
   $followupDefinition: String
   $rendererFollowupDataTemplate: String
   $isFollowable: Boolean
+  $metricAccumulation: String
 ) {
   adminReportTypeUpdate(
     id: $id
@@ -127,6 +130,7 @@ mutation ReportTypeUpdate(
     followupDefinition: $followupDefinition
     rendererFollowupDataTemplate: $rendererFollowupDataTemplate
     isFollowable: $isFollowable
+    metricAccumulation: $metricAccumulation
   ) {
     result {
       __typename
@@ -147,6 +151,7 @@ mutation ReportTypeUpdate(
           followupDefinition
           rendererFollowupDataTemplate
           isFollowable
+          metricAccumulation
           ordering
         }
       }
@@ -200,6 +205,7 @@ query GetReportType($id: ID!) {
     followupDefinition
     rendererFollowupDataTemplate
     isFollowable
+    metricAccumulation
     ordering
   }
 }

--- a/lib/services/reportType/reportType.ts
+++ b/lib/services/reportType/reportType.ts
@@ -12,6 +12,8 @@ export type ReportType = {
   rendererFollowupDataTemplate?: string;
   published?: boolean;
   isFollowable?: boolean;
+  /** JSON string of metric accumulation config (ReportType.metric_accumulation). */
+  metricAccumulation?: string;
 };
 
 export type SimulationReportType = {

--- a/lib/services/reportType/reportTypeService.ts
+++ b/lib/services/reportType/reportTypeService.ts
@@ -53,7 +53,8 @@ export interface IReportTypeService extends IService {
     rendererDataTemplate?: string,
     followupDefinition?: string,
     rendererFollowupDataTemplate?: string,
-    isFollowable?: boolean
+    isFollowable?: boolean,
+    metricAccumulation?: string
   ): Promise<SaveResult<ReportType>>;
 
   updateReportType(
@@ -66,7 +67,8 @@ export interface IReportTypeService extends IService {
     rendererDataTemplate?: string,
     followupDefinition?: string,
     rendererFollowupDataTemplate?: string,
-    isFollowable?: boolean
+    isFollowable?: boolean,
+    metricAccumulation?: string
   ): Promise<SaveResult<ReportType>>;
 
   deleteReportType(id: string): Promise<DeleteResult>;
@@ -223,6 +225,9 @@ export class ReportTypeService implements IReportTypeService {
         rendererFollowupDataTemplate:
           reportType.rendererFollowupDataTemplate || undefined,
         isFollowable: reportType.isFollowable,
+        metricAccumulation: reportType.metricAccumulation
+          ? JSON.stringify(reportType.metricAccumulation, null, 2)
+          : "",
       };
     }
     return {
@@ -259,7 +264,8 @@ export class ReportTypeService implements IReportTypeService {
     rendererDataTemplate?: string,
     followupDefinition?: string,
     rendererFollowupDataTemplate?: string,
-    isFollowable?: boolean
+    isFollowable?: boolean,
+    metricAccumulation?: string
   ): Promise<SaveResult<ReportType>> {
     const createResult = await this.client.mutate({
       mutation: ReportTypeCreateDocument,
@@ -273,6 +279,7 @@ export class ReportTypeService implements IReportTypeService {
         followupDefinition,
         rendererFollowupDataTemplate,
         isFollowable,
+        metricAccumulation: metricAccumulation || undefined,
       },
       refetchQueries: [
         {
@@ -326,7 +333,8 @@ export class ReportTypeService implements IReportTypeService {
     rendererDataTemplate?: string,
     followupDefinition?: string,
     rendererFollowupDataTemplate?: string,
-    isFollowable?: boolean
+    isFollowable?: boolean,
+    metricAccumulation?: string
   ): Promise<SaveResult<ReportType>> {
     const updateResult = await this.client.mutate({
       mutation: ReportTypeUpdateDocument,
@@ -341,6 +349,7 @@ export class ReportTypeService implements IReportTypeService {
         followupDefinition,
         rendererFollowupDataTemplate,
         isFollowable,
+        metricAccumulation: metricAccumulation || undefined,
       },
       refetchQueries: [
         {


### PR DESCRIPTION
## Summary
- Wire `metricAccumulation` through report-type GraphQL and admin create/update
- Show totals card on incident detail
- Export/import preserves isFollowable + metric map

## Depends on
- ohtk-api feature/metric-accumulation

## Test plan
- [ ] Save report type with metric JSON
- [ ] Incident detail shows totals after follow-ups